### PR TITLE
Update to correctly parse group admins hierarchy

### DIFF
--- a/src/WinFormsApp/Models/Group.cs
+++ b/src/WinFormsApp/Models/Group.cs
@@ -47,7 +47,7 @@ namespace NMARC.Models
         public string GetCsv()
         {
             return
-                $@"{Id},{Name},{Type},{PrivacySetting},{State},{MessageCount},{LastMessageDate},{ConnectedToO365},{Administrators},{Memberships.External},{Memberships.Internal},{Uploads.SharePoint},{Uploads.Yammer}";
+                $@"{Id},{Name},{Type},{PrivacySetting},{State},{MessageCount},{LastMessageDate},{ConnectedToO365},{Memberships.External},{Memberships.Internal},{Uploads.SharePoint},{Uploads.Yammer}";
         }
     }
 }

--- a/src/WinFormsApp/NativeModeReportViewer.csproj
+++ b/src/WinFormsApp/NativeModeReportViewer.csproj
@@ -101,6 +101,8 @@
   <ItemGroup>
     <None Include="App.config" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <WCFMetadata Include="Connected Services\" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
Groups admins and their creation rights info is now output with the relevant group ID in a separate file.