### PR TITLE
Adding support for getting the list of active group-level legacy guests (aka external group users from other canonical networks.)

### DIFF
--- a/src/NativeModeReportViewerPackaging/Package.appxmanifest
+++ b/src/NativeModeReportViewerPackaging/Package.appxmanifest
@@ -9,7 +9,7 @@
   <Identity
     Name="62908BrianLyttle.NMARC"
     Publisher="CN=682375EB-F630-49C7-8CBC-69A6E7AF1C2B"
-    Version="1.0.4.0" />
+    Version="1.0.5.0" />
 
   <Properties>
     <DisplayName>NMARC</DisplayName>

--- a/src/WinFormsApp/MainWindow.cs
+++ b/src/WinFormsApp/MainWindow.cs
@@ -87,6 +87,8 @@ namespace NMARC
             WriteUsersReport(report, basePath);
 
             WriteGroupAdminsReport(report, basePath);
+
+            WriteCommunityGuestsReport(report, basePath);
         }
 
         private static void WriteGroupAdminsReport(AlignmentReport report, string basePath)
@@ -122,6 +124,27 @@ namespace NMARC
             }
 
             Utilities.WriteFile($@"{basePath}\groupadmins.txt", groupAdminOutput);
+        }
+
+        private static void WriteCommunityGuestsReport(AlignmentReport report, string basePath)
+        {
+            var communityGuestOutput = new StringBuilder();
+            communityGuestOutput.AppendLine("GroupID,Email");
+
+            foreach (var group in report.Groups)
+            {
+                if(group.ActiveCommunityGuests != null) { 
+                    if(group.ActiveCommunityGuests.Count > 0)
+                    {
+                        foreach (var guest in group.ActiveCommunityGuests)
+                        {
+                            communityGuestOutput.AppendLine($"{group.Id},{guest}");
+                        }
+                    }
+                }
+            }
+
+            Utilities.WriteFile($@"{basePath}\communityguests.txt", communityGuestOutput);
         }
 
         private static void WriteUsersReport(AlignmentReport report, string basePath)

--- a/src/WinFormsApp/MainWindow.resx
+++ b/src/WinFormsApp/MainWindow.resx
@@ -126,9 +126,6 @@
   <metadata name="DlgSelectOutputFolder.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>144, 17</value>
   </metadata>
-  <metadata name="toolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>320, 17</value>
-  </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>

--- a/src/WinFormsApp/Models/Group.cs
+++ b/src/WinFormsApp/Models/Group.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using YamlDotNet.Serialization;
 
 namespace NMARC.Models
@@ -39,6 +40,9 @@ namespace NMARC.Models
 
         [YamlMember(Alias = "group_admins", ApplyNamingConventions = false)]
         public object Administrators { get; set; }
+
+        [YamlMember(Alias = "active_community_guests", ApplyNamingConventions = false)]
+        public List<string> ActiveCommunityGuests { get; set; }
 
         /// <summary>
         /// Gets a representation of the group as a row of CSV


### PR DESCRIPTION
This outputs an additional file in the regular output directory.